### PR TITLE
Use special-mode for the output buffer so `q` can be used to quit

### DIFF
--- a/dap-mode.el
+++ b/dap-mode.el
@@ -911,6 +911,7 @@ PARAMS are the event params.")
   "Creates an output buffer with with name SESSION-NAME."
   (with-current-buffer (get-buffer-create (concat "*" session-name " out*"))
     (set (make-local-variable 'window-point-insertion-type) t)
+    (special-mode)
     (current-buffer)))
 
 (defun dap--make-request (command &optional args)


### PR DESCRIPTION
Sets the output buffer to read only and allows quitting by pressing
`q` which makes for a nice dev workflow, as you switch back to the
buffer where you started rather than having to manually kill the
buffer and navigate back.